### PR TITLE
Adiciona RabbitMQ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,4 @@ gem "graphql", "~> 2.3"
 gem "graphiql-rails"
 
 # Rabbit
-gem "sneakers"
 gem "bunny", ">= 2.19.0"

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ group :development do
   gem "spring"
 end
 
+group :test do
+  gem "bunny-mock"
+end
+
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # graphql

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
     bunny (2.22.0)
       amq-protocol (~> 2.3, >= 2.3.1)
       sorted_set (~> 1, >= 1.0.2)
+    bunny-mock (1.7.0)
+      bunny (>= 1.7)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.3.3)
@@ -262,6 +264,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   bunny (>= 2.19.0)
+  bunny-mock
   graphiql-rails
   graphql (~> 2.3)
   listen (~> 3.3)

--- a/app/graphql/mutations/policy_create.rb
+++ b/app/graphql/mutations/policy_create.rb
@@ -9,6 +9,7 @@ module Mutations
     argument :policy_input, Types::PolicyInputType, required: true
 
     def resolve(policy_input:)
+      Producer.publish(policy_input)
       {
         message: "Policy created"
       }

--- a/app/services/producer.rb
+++ b/app/services/producer.rb
@@ -1,0 +1,18 @@
+require "bunny"
+
+class Producer
+  class << self
+    def publish(message = {})
+      extrange = channel.fanout("policy_created")
+      extrange.publish(message.to_json)
+    end
+
+    def channel
+      @channel ||= connection.create_channel
+    end
+
+    def connection
+      Bunny.new(host: "rabbitmq", user: "user", pass: "password").start
+    end
+  end
+end

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,19 @@
+services:
+  web:
+    networks:
+      - public
+      - private
+    container_name: graphql_app
+  db:
+    networks:
+      - private
+  rabbitmq:
+    networks:
+      - public
+
+networks:
+  public:
+    external: true
+  private:
+    external: false
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,18 @@ services:
       - ./tmp/db:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: password
+  rabbitmq:
+    image: rabbitmq:3-management
+    hostname: rabbitmq
+    ports:
+    - "5672:5672"
+    - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password
   web:
+    tty: true
+    stdin_open: true
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
@@ -14,3 +25,4 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
   rabbitmq:
     image: rabbitmq:3-management
     hostname: rabbitmq
-    ports:
-    - "5672:5672"
-    - "15672:15672"
+    expose:
+      - "5672"
     environment:
       RABBITMQ_DEFAULT_USER: user
       RABBITMQ_DEFAULT_PASS: password
@@ -21,8 +20,12 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
+      - gems_cache:/usr/local/bundle
     ports:
       - "3000:3000"
     depends_on:
       - db
       - rabbitmq
+
+volumes:
+  gems_cache:

--- a/spec/services/producer_spec.rb
+++ b/spec/services/producer_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+require "bunny-mock"
+
+RSpec.describe Producer do
+  let(:connection) { BunnyMock.new }
+  let(:channel) { connection.create_channel }
+  let(:exchange) { channel.fanout("policy_created") }
+  let(:message) do
+    {
+      start_date_coverage: "1994-10-05",
+      end_date_coverage: "1998-11-10",
+      vehicle: {
+        brand: "Ford",
+        model: "Falcon GT",
+        year: "1973",
+        registration_plate: "Interceptor-v6"
+      },
+      insured: {
+        name: "Mad Max",
+        cpf: "96151218000"
+      }
+    }
+  end
+
+  before do
+    allow(Bunny).to receive(:new).and_return(connection)
+  end
+
+  describe ".publish" do
+    it "publishes a message to the policy_created exchange" do
+      expect(exchange).to receive(:publish).with(message.to_json)
+
+      described_class.publish(message)
+
+      expect(exchange.name).to eq("policy_created")
+      expect(exchange.opts[:type]).to eq(:fanout)
+    end
+  end
+
+  describe ".channel" do
+    it "creates a new channel" do
+      expect(described_class.channel).to be_a(BunnyMock::Channel)
+    end
+  end
+
+  describe ".connection" do
+    it "creates a new connection" do
+      expect(described_class.connection).to be_a(BunnyMock::Session)
+    end
+  end
+end


### PR DESCRIPTION
## O que mudou
adiciona mutation de criação da apólice

## Motivação
Precisamos adicionar o rabbitmq ao projeto, a mutation de criação de apólice deve mandar os dados de criação como mensagem para ser consumida pelo app_rest

## Solução proposta
O rabbitmq foi adicionado como um serviço ao docker-compose, adicionamos um service chamado "Producer" responsável por publicar as mensagens numa fila para serem consumidas pelo outro APP.

## Como testar
Suba o projeto com o comando `docker-compose up`

### GraphiQL:

<details>
<summary><strong>Crie uma nova apólice</strong>  </summary><br>

* Acessar o [endereço](http://localhost:15672/#/exchanges)
* Username: "user"
* Password: "password"

* Verifique que não existe nenhum exchange chamada "police_created"

* Acesse http://0.0.0.0:3000/graphiql
* cole o código abaixo

#### Exemplo de Mutation
```GQL
mutation{
  policyCreate(input: {policyInput: {
    start_date_coverage: "1994-10-05"
    end_date_coverage: "1994-11-10"
    vehicle: {
      brand: "Ford"
      model: "Falcon GT"
      year: "1973"
      registration_plate: "Interceptor-v6"
    	}
    insured: {
      name: "Mad Max"
      cpf: "96151218000"
    }
  	}
  }
  ) {
    message
  }
}

```

* Acessar o novamente o [endereço](http://localhost:15672/#/exchanges)
* Verifique que o exchange "police_created" está presente

### Resposta Esperada
![Captura de tela de 2024-06-28 17-21-21](https://github.com/ventopreto/graphql_app/assets/67896322/5e83dc2a-286c-4c91-af98-50c1e69e44d6)

</details>

## Riscos
Por conta da adição de um novo serviço ao docker-compose, podemos ter erros ao subir o projeto, assim como problemas durante a criação da apolice

## Impactos negativos previstos
Nenhum Impacto previsto

## Instruções para deploy
Nenhuma instrução adicional

## Instruções para retorno
rollback padrão desse PR

