### PR TITLE
cria endpoint de consulta da policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ vendor
 tmp
 public
 .env
+.vscode

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "puma", "~> 5.0"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "devise-jwt"
+gem "faraday"
 
 group :development, :test do
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,11 @@ GEM
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     erubi (1.13.0)
+    faraday (2.10.0)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-net_http (3.1.0)
+      net-http
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -115,6 +120,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -128,6 +134,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.24.0)
     msgpack (1.7.2)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.13)
       date
       net-protocol
@@ -270,6 +278,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-jwt_auth (0.10.0)
@@ -292,6 +301,7 @@ DEPENDENCIES
   devise
   devise-jwt
   dotenv
+  faraday
   graphiql-rails
   graphql (~> 2.3)
   listen (~> 3.3)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -10,7 +10,7 @@ class GraphqlController < ApplicationController
     variables = prepare_variables(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
-    context = {authenticated?: authenticated?}
+    context = {authenticated?: authenticated?, token: @token}
     result = MyappSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
   rescue => e

--- a/app/graphql/mutations/policy_create.rb
+++ b/app/graphql/mutations/policy_create.rb
@@ -16,7 +16,7 @@ module Mutations
     end
 
     def self.authorized?(obj, context)
-      super && if context[:authencicated?]
+      super && if context[:authenticated?]
         true
       else
         raise GraphQL::ExecutionError, "Not Authenticated"

--- a/app/graphql/types/insured_type.rb
+++ b/app/graphql/types/insured_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class InsuredType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String
+    field :cpf, ID
+  end
+end

--- a/app/graphql/types/policy_response_type.rb
+++ b/app/graphql/types/policy_response_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class PolicyResponseType < Types::BaseObject
+    field :policy, Types::PolicyType
+    field :vehicle, Types::VehicleType
+    field :insured, Types::InsuredType
+  end
+end

--- a/app/graphql/types/policy_type.rb
+++ b/app/graphql/types/policy_type.rb
@@ -3,8 +3,8 @@
 module Types
   class PolicyType < Types::BaseObject
     field :id, ID, null: false
-    field :start_date, GraphQL::Types::ISO8601DateTime, null: false
-    field :end_date, GraphQL::Types::ISO8601DateTime, null: false
+    field :start_date_coverage, GraphQL::Types::ISO8601DateTime
+    field :end_date_coverage, GraphQL::Types::ISO8601DateTime
     field :created_at, GraphQL::Types::ISO8601DateTime
     field :updated_at, GraphQL::Types::ISO8601DateTime
     field :insured_id, ID, null: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -38,7 +38,7 @@ module Types
     end
 
     def self.authorized?(obj, context)
-      super && if context[:authencicated?]
+      super && if context[:authenticated?]
         true
       else
         raise GraphQL::ExecutionError, "Not Authenticated"

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -26,5 +26,32 @@ module Types
     def test_field
       "Hello World!"
     end
+
+    field :get_policy, Types::PolicyResponseType, null: false, description: "Fetch policy for some id" do
+      argument :id, ID, required: true
+    end
+
+    def get_policy(id:)
+      headers = {Authorization: "Bearer #{context[:token]}"}
+      response = Faraday.get("http://rest_app:3001/api/v1/policy/#{id}", nil, headers)
+      parsed_response(response)
+    end
+
+    def self.authorized?(obj, context)
+      super && if context[:authencicated?]
+        true
+      else
+        raise GraphQL::ExecutionError, "Not Authenticated"
+      end
+    end
+
+    private
+
+    def parsed_response(response)
+      return response.body if response.status == 401
+      json = JSON.parse(response.body, symbolize_names: true)[:payload]
+      json[:policy] = {id: json.delete(:policy_id), end_date_coverage: json.delete(:end_date_coverage), start_date_coverage: json.delete(:start_date_coverage)}
+      json
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.hosts << "graphql_app"
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/spec/graphql/mutations/policy_create_spec.rb
+++ b/spec/graphql/mutations/policy_create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Policy", type: :request do
 
     context "when not authenticated" do
       it "raise an error saying Not Authenticated" do
-        result = MyappSchema.execute(query_string, context: {authencicated?: false}, variables: {
+        result = MyappSchema.execute(query_string, context: {authenticated?: false}, variables: {
           start_date_coverage: "1994-10-05",
           end_date_coverage: "1998-11-10",
           vehicle: {
@@ -43,7 +43,7 @@ RSpec.describe "Policy", type: :request do
 
     context "when authenticated and valid" do
       it "create a policy" do
-        result = MyappSchema.execute(query_string, context: {authencicated?: true}, variables: {
+        result = MyappSchema.execute(query_string, context: {authenticated?: true}, variables: {
           start_date_coverage: "1994-10-05",
           end_date_coverage: "1998-11-10",
           vehicle: {

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+require "devise/jwt/test_helpers"
+
+RSpec.describe "Policy", type: :request do
+  context "Mutation policy" do
+    let(:query_string) do
+      <<-GRAPHQL
+      query($id: ID!) {
+        getPolicy(id: $id) {
+          insured{
+            cpf
+            name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    let(:response) do
+      double(Faraday::Response, status: 200, body: "{\"payload\":{\"policy_id\":3,\"start_date_coverage\":\"1969-01-10\",\"end_date_coverage\":\"2030-01-10\",\"insured\":{\"name\":\"Bo Duke\",\"cpf\":\"23456789012\"},\"vehicle\":{\"brand\":\"Dodge\",\"model\":\"Charger\",\"year\":\"1969\",\"registration_plate\":\"General Lee\"}}}")
+    end
+
+    context "when not authenticated" do
+      it "raise an error saying Not Authenticated" do
+        result = MyappSchema.execute(query_string, context: {authencicated?: false}, variables: {id: 1})
+
+        expect(result["errors"].first["message"]).to eq("Not Authenticated")
+      end
+    end
+
+    context "when authenticated and valid" do
+      before { allow(Faraday).to receive(:get).and_return(response) }
+
+      it "raise an error saying Not Authenticated" do
+        result = MyappSchema.execute(query_string, context: {authencicated?: true}, variables: {id: 3})
+
+        expect(result["data"]["getPolicy"]["insured"]["cpf"]).to eq("23456789012")
+        expect(result["data"]["getPolicy"]["insured"]["name"]).to eq("Bo Duke")
+      end
+    end
+  end
+end

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Policy", type: :request do
 
     context "when not authenticated" do
       it "raise an error saying Not Authenticated" do
-        result = MyappSchema.execute(query_string, context: {authencicated?: false}, variables: {id: 1})
+        result = MyappSchema.execute(query_string, context: {authenticated?: false}, variables: {id: 1})
 
         expect(result["errors"].first["message"]).to eq("Not Authenticated")
       end
@@ -32,7 +32,7 @@ RSpec.describe "Policy", type: :request do
       before { allow(Faraday).to receive(:get).and_return(response) }
 
       it "raise an error saying Not Authenticated" do
-        result = MyappSchema.execute(query_string, context: {authencicated?: true}, variables: {id: 3})
+        result = MyappSchema.execute(query_string, context: {authenticated?: true}, variables: {id: 3})
 
         expect(result["data"]["getPolicy"]["insured"]["cpf"]).to eq("23456789012")
         expect(result["data"]["getPolicy"]["insured"]["name"]).to eq("Bo Duke")


### PR DESCRIPTION
## O que mudou
Agora é possível consultar uma policy criada

## Motivação
Para os passos futuros vamos precisar dessa rota

## Solução proposta
Criados uma nova rota do tipo query

## Como testar
### [APP front](https://github.com/ventopreto/front_app/pull/3)
* Suba o` front app` utilizando o comando `docker-compose up`
* Vá para http://localhost:3000/users/sign_up
* Preencha o e-mail, senha e confirme a senha
* Clique em Sign up
* Um token deve ser gerado, copie o token

### APP Rest
* Suba o` rest app` utilizando o comando `docker-compose -f docker-compose.yml -f docker-compose.local.yml up`

### APP graphql
* Suba o` grahpql app` utilizando o comando `docker-compose -f docker-compose.yml -f docker-compose.local.yml up`
* Acesse http://localhost:3002/graphiql
* Na aba variaveis cole o token criado no front
* cole o código abaixo

#### Exemplo de query
```GQL
query{
  getPolicy(id:1){
    insured {
      cpf
    }
  }
}

```

Logo a baixo procure pelo botão Headers

```JSON
{
  "authorization": "Bearer <token copiado do front>"
}

```

![Captura de tela de 2024-07-22 15-37-26](https://github.com/user-attachments/assets/bfaea24c-9bcb-4718-a0bc-bb75e4f35f1f)


## Riscos
Podemos ter algum problema durante a consulta da apolice por alguma falta de configuração entre o rest app e o graphql

## Impactos negativos previstos
Nenhum Impacto previsto

## Instruções para deploy
Nenhuma instrução adicional

## Instruções para retorno
rollback padrão desse PR
